### PR TITLE
Render poet colors on the server to eliminate flicker.

### DIFF
--- a/public/js/poems/edit.js
+++ b/public/js/poems/edit.js
@@ -9,28 +9,12 @@ $(function() {
     socket.emit('joinPoem', poemId);
   });
 
-  function assignColorToLine(lineElement) {
-    var poetId = $(lineElement).data('poet-id');
-    var poetColor = poemContainer.find('.poet[data-poet-id=' + poetId + ']').css('background-color');
-    $(lineElement).find('.box').css('background-color', poetColor);
-  }
-
-  (function assignColorsToPoets() {
-    var poetColors = [
-      '#a8aabd','#8db099','#abb08d','#b08f8d','#b08daa',
-      '#8d8db0','#8da6b0','#8db095','#aab08d'];
-    var poets = poemContainer.find('.poet').each(function(i, el) {
-      $(el).css('background-color', poetColors[i % poetColors.length]);
-    });
-    linesContainer.find('.line').each(function(i, el) {
-      assignColorToLine(el);
-    });
-  })();
-
   socket.on('line-created-for-poem-' + poemId, function(poemLine) {
-    var lineDiv = $(jade.render('server/views/partials/line.jade', { line: poemLine }));
+    var lineDiv = $(jade.render('server/views/partials/line.jade', {
+      line: poemLine,
+      poets: $('.poet').map(function(i, poet) { return { id: $(poet).data('poet-id') }; })
+    }));
     lineDiv.appendTo(linesContainer);
-    assignColorToLine(lineDiv);
     $(document).scrollTop($(document).height());
     lineTextInput.focus();
   });

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -78,6 +78,16 @@ h1 {
   margin-left: 2px;
 }
 
+.poet-color-0 { background-color: #a8aabd; }
+.poet-color-1 { background-color: #8db099; }
+.poet-color-2 { background-color: #abb08d; }
+.poet-color-3 { background-color: #b08f8d; }
+.poet-color-4 { background-color: #b08daa; }
+.poet-color-5 { background-color: #8d8db0; }
+.poet-color-6 { background-color: #8da6b0; }
+.poet-color-7 { background-color: #8db095; }
+.poet-color-8 { background-color: #aab08d; }
+
 .poet {
   margin-right: 3px;
   text-align: center;

--- a/server/views/partials/line.jade
+++ b/server/views/partials/line.jade
@@ -1,3 +1,5 @@
+include poet-color
+
 .line(data-poet-id="#{line.poetId}")
-  .box
+  .box(class="#{poetColorClass(line.poetId)}")
   span= line.text

--- a/server/views/partials/poet-color.jade
+++ b/server/views/partials/poet-color.jade
@@ -1,0 +1,5 @@
+- var poetColorClass = function(poetId){
+-   for(var i=0; i<poets.length; i++) {
+-     if (poets[i].id === poetId) { return "poet-color-" + (i % 9); }
+-   }
+- }

--- a/server/views/poems/edit.jade
+++ b/server/views/poems/edit.jade
@@ -1,12 +1,14 @@
 extends ../layout
 
 block content
+  include ../partials/poet-color
+
   #poem-edit-header-panel
   #poem-edit-header(data-poem-id="#{poem.id}")
     h1= poem.name
     .poets
-      each poet, index in poets
-        .poet(data-poet-id="#{poet.id}") #{poet.name}
+      each poet in poets
+        .poet(data-poet-id="#{poet.id}", class="#{poetColorClass(poet.id)}") #{poet.name}
     form.newline-form(action="javascript:void(0)", data-poet-id="#{user.id}")
       input.line-text(type="text", size=100)
       input(type="submit", value="Post")


### PR DESCRIPTION
There are some tricky bits to this implementation. There is a poet-color partial that contains a function to compute the poet color css class from the poetId. The client needs to provide the partial with a list of poet objects, but it just creates object literals with a poet id property, because that is all that is required by the poetColorClass function.  Would be nice to find a way to avoid having to do this.
